### PR TITLE
return pointer to buffer for page getter

### DIFF
--- a/mempager/pager.go
+++ b/mempager/pager.go
@@ -13,9 +13,9 @@ func (p Page) Offset() int {
 	return p.offset
 }
 
-// Buffer returns the internal buffer for the page
-func (p Page) Buffer() []byte {
-	return p.buffer
+// Buffer returns a pointer to the internal byte buffer of the page
+func (p Page) Buffer() *[]byte {
+	return &p.buffer
 }
 
 // Pager is a tool used to reference chunks of memory (pages)
@@ -58,7 +58,7 @@ func (p *Pager) GetOrAlloc(pageNum int) (page *Page) {
 	p.growPages(pageNum)
 
 	if page = p.pages[pageNum]; page == nil {
-		p.pages[pageNum] = p.newPage(pageNum, nil)
+		p.pages[pageNum] = p.newPage(pageNum, make([]byte, p.pageSize))
 		page = p.pages[pageNum]
 	}
 

--- a/mempager/pager_test.go
+++ b/mempager/pager_test.go
@@ -26,7 +26,7 @@ func Test_Pager_DefaultPageSize(t *testing.T) {
 	assert.Equal(t, true, pgr.IsEmpty(), "Empty() should be true")
 	assert.Equal(t, (*Page)(nil), pgr.Get(12), "Get() should return nil")
 	assert.Equal(t, true, pgr.IsEmpty(), "Empty() should be still be true")
-	assert.Equal(t, &Page{offset: DEFAULT_PAGE_SIZE * 12}, pgr.GetOrAlloc(12), "GetOrAlloc() should return newly allocated page")
+	assert.Equal(t, &Page{offset: DEFAULT_PAGE_SIZE * 12, buffer: make([]byte, DEFAULT_PAGE_SIZE)}, pgr.GetOrAlloc(12), "GetOrAlloc() should return newly allocated page")
 	assert.Equal(t, false, pgr.IsEmpty(), "Empty() should be now be false")
 	assert.Equal(t, 13, pgr.Len(), "Len() should be 13")
 
@@ -46,11 +46,11 @@ func Test_Pager_CustomPageSize(t *testing.T) {
 	pageSize := 512
 	pgr := NewPager(pageSize)
 
-	assert.Equal(t, pageSize, pgr.PageSize(), "PageSize() should be %s", DEFAULT_PAGE_SIZE)
+	assert.Equal(t, pageSize, pgr.PageSize(), "PageSize() should be %s", pageSize)
 	assert.Equal(t, true, pgr.IsEmpty(), "Empty() should be true")
 	assert.Equal(t, (*Page)(nil), pgr.Get(12), "Get() should return nil")
 	assert.Equal(t, true, pgr.IsEmpty(), "Empty() should be still be true")
-	assert.Equal(t, &Page{offset: pageSize * 12}, pgr.GetOrAlloc(12), "GetOrAlloc() should return newly allocated page")
+	assert.Equal(t, &Page{offset: pageSize * 12, buffer: make([]byte, 512)}, pgr.GetOrAlloc(12), "GetOrAlloc() should return newly allocated page")
 	assert.Equal(t, false, pgr.IsEmpty(), "Empty() should be now be false")
 	assert.Equal(t, 13, pgr.Len(), "Len() should be 13")
 
@@ -62,4 +62,37 @@ func Test_Pager_CustomPageSize(t *testing.T) {
 
 	pgr.Set(3, make([]byte, 1000))
 	assert.Equal(t, &Page{offset: pageSize * 3, buffer: make([]byte, pageSize)}, pgr.Get(3), "Set() should truncate the provided buffer down to the page size")
+}
+
+func Test_Pager_SetBytesOnPage(t *testing.T) {
+	t.Parallel()
+
+	pgr := NewPager(0)
+
+	page := pgr.GetOrAlloc(1)
+	buf := page.Buffer()
+
+	expected := make([]byte, DEFAULT_PAGE_SIZE)
+	for i, byte := range []byte("hello!") {
+		(*buf)[i] = byte
+		expected[i] = byte
+	}
+
+	checkpage := pgr.Get(1)
+	buf = checkpage.Buffer()
+	assert.Equal(t, expected, *buf)
+}
+
+func Test_Pager_CantReplacePageBufferPointer(t *testing.T) {
+	t.Parallel()
+
+	pgr := NewPager(0)
+
+	page := pgr.GetOrAlloc(1)
+	buf := page.Buffer()
+	*buf = []byte("foobar")
+
+	checkpage := pgr.Get(1)
+	buf = checkpage.Buffer()
+	assert.Equal(t, make([]byte, DEFAULT_PAGE_SIZE), *buf)
 }


### PR DESCRIPTION
`page.Buffer()` now returns a pointer to the internal buffer, allowing for setting bytes on the page. still prevents replacing the buffer with one that would violate the page size, as shown in the tests.