### PR TITLE
Use new instance of stream in each benchmark run

### DIFF
--- a/merkle/stream_test.go
+++ b/merkle/stream_test.go
@@ -87,9 +87,8 @@ func Benchmark_Blake2BStream10000(b *testing.B) {
 }
 
 func benchmarkBlake2BStream(i int, b *testing.B) {
-	stream := NewStream(blake2bHasher, nil, nil)
-
 	for n := 0; n < b.N; n++ {
+		stream := NewStream(blake2bHasher, nil, nil)
 		for j := 0; j < i; j++ {
 			stream.Append([]byte(fmt.Sprint(j)))
 		}


### PR DESCRIPTION
Out of interest the change to the bench this gave me:
```
Before:
Benchmark_Blake2BStream100-12      	    9046	    140954 ns/op	   89471 B/op	    1490 allocs/op
Benchmark_Blake2BStream1000-12     	     829	   1296178 ns/op	  876972 B/op	   15734 allocs/op
Benchmark_Blake2BStream10000-12    	      85	  12355890 ns/op	 8747621 B/op	  159735 allocs/op

After:
Benchmark_Blake2BStream100-12      	    9475	    114976 ns/op	   77605 B/op	    1485 allocs/op
Benchmark_Blake2BStream1000-12     	    1084	   1126313 ns/op	  829872 B/op	   15715 allocs/op
Benchmark_Blake2BStream10000-12    	     100	  12228626 ns/op	 8898885 B/op	  159750 allocs/op
```