### PR TITLE
Bench mempager growth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.temp
+.vscode/

--- a/mempager/pager.go
+++ b/mempager/pager.go
@@ -89,9 +89,12 @@ func (p *Pager) Set(pageNum int, data []byte) {
 
 // growPages will increases the size of the pager's page buffer up till the supplied index
 func (p *Pager) growPages(index int) {
-	for i := len(p.pages); i <= index; i++ {
-		p.pages = append(p.pages, nil)
+	diff := index - len(p.pages)
+	if diff <= 0 {
+		return
 	}
+	padding := make([]*Page, diff+1)
+	p.pages = append(p.pages, padding...)
 }
 
 func (p Pager) truncate(buf []byte) []byte {

--- a/mempager/pager_test.go
+++ b/mempager/pager_test.go
@@ -96,3 +96,19 @@ func Test_Pager_CantReplacePageBufferPointer(t *testing.T) {
 	buf = checkpage.Buffer()
 	assert.Equal(t, make([]byte, DEFAULT_PAGE_SIZE), *buf)
 }
+
+func Benchmark_PagerGrowPages100(b *testing.B) {
+	benchmarkPagerPageGrowth(100, b)
+}
+
+func Benchmark_PagerGrowPages100000(b *testing.B) {
+	benchmarkPagerPageGrowth(100000, b)
+}
+
+func benchmarkPagerPageGrowth(i int, b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		pgr := NewPager(0)
+		pgr.GetOrAlloc(1)
+		pgr.GetOrAlloc(i)
+	}
+}


### PR DESCRIPTION
I have no idea if this is (a) idiomatic go, and (b) a realistic thing to care about for the usage of this api, I'm just amazed I managed to get the tests to pass.

```
Before:
goos: darwin
goarch: amd64
pkg: github.com/kiambogo/go-hypercore/mempager
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
Benchmark_PagerGrowPages100-12       	  750114	      1357 ns/op	    4152 B/op	      12 allocs/op
Benchmark_PagerGrowPages100000-12    	     784	   1558879 ns/op	 4656489 B/op	      34 allocs/op


After:
goos: darwin
goarch: amd64
pkg: github.com/kiambogo/go-hypercore/mempager
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
Benchmark_PagerGrowPages100-12       	 1000000	      1006 ns/op	    3936 B/op	       8 allocs/op
Benchmark_PagerGrowPages100000-12    	    2830	    510968 ns/op	 1607811 B/op	       8 allocs/op
```