### PR TITLE
Bitfield RLE

### DIFF
--- a/bitfield/rle.go
+++ b/bitfield/rle.go
@@ -1,0 +1,9 @@
+package bitfield
+
+func Encode() {
+
+}
+
+func Decode() {
+
+}

--- a/bitfield/rle.go
+++ b/bitfield/rle.go
@@ -1,7 +1,39 @@
 package bitfield
 
-func Encode() {
+import (
+	"encoding/binary"
+	"log"
+)
 
+func Encode(data []byte) ([]byte, bool) {
+	encodedData := []byte{}
+
+	if len(data) == 0 {
+		return data, false
+	}
+
+	currentRunByte := data[0]
+	var currentRunLength int64 = 1
+	for _, b := range data {
+		if b == currentRunByte {
+			currentRunLength++
+			continue
+		}
+
+		crlBuf := make([]byte, binary.MaxVarintLen64)
+		_ = binary.PutVarint(crlBuf, currentRunLength)
+		crlBuf = append(crlBuf, currentRunByte)
+		encodedData = append(encodedData, crlBuf...)
+		currentRunByte = b
+		currentRunLength = 1
+	}
+
+	if len(encodedData) >= len(data) {
+		log.Printf("encoded: %d is gt than orig: %d", len(encodedData), len(data))
+		return data, false
+	}
+
+	return encodedData, true
 }
 
 func Decode() {

--- a/bitfield/rle.go
+++ b/bitfield/rle.go
@@ -3,7 +3,6 @@ package bitfield
 import (
 	"bytes"
 	"encoding/binary"
-	"fmt"
 )
 
 func Encode(data []byte) ([]byte, bool) {
@@ -58,9 +57,10 @@ func Decode(encoded []byte) ([]byte, error) {
 			return nil, err
 		}
 
-		s := fmt.Sprintf("%d%s", count, string(charByte))
-		if _, err = decoded.WriteString(s); err != nil {
-			return nil, err
+		for n := int64(0); n < count; n++ {
+			if err := decoded.WriteByte(charByte); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/bitfield/rle_test.go
+++ b/bitfield/rle_test.go
@@ -1,0 +1,17 @@
+package bitfield
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Encode(t *testing.T) {
+	t.Parallel()
+
+	orig := []byte("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABCCCCDDEFGHHH")
+	encodedData, encoded := Encode(orig)
+	assert.True(t, encoded)
+	assert.Equal(t, "", string(encodedData))
+
+}

--- a/bitfield/rle_test.go
+++ b/bitfield/rle_test.go
@@ -1,6 +1,7 @@
 package bitfield
 
 import (
+	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,6 +13,7 @@ func Test_Encode(t *testing.T) {
 	orig := []byte("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABCCCCDDEFGHHH")
 	encodedData, encoded := Encode(orig)
 	assert.True(t, encoded)
-	assert.Equal(t, "", string(encodedData))
+	log.Println(Decode(encodedData))
+	// assert.Equal(t, "", string(encodedData))
 
 }

--- a/bitfield/rle_test.go
+++ b/bitfield/rle_test.go
@@ -1,7 +1,6 @@
 package bitfield
 
 import (
-	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,11 +8,78 @@ import (
 
 func Test_Encode(t *testing.T) {
 	t.Parallel()
+	testCases := []struct {
+		name            string
+		input           []byte
+		shouldEncode    bool
+		expectedEncoded []byte
+	}{
+		{
+			name:            "empty input",
+			input:           []byte{},
+			shouldEncode:    false,
+			expectedEncoded: []byte{},
+		},
+		{
+			name:            "smaller decoded than encoded",
+			input:           []byte("a"),
+			shouldEncode:    false,
+			expectedEncoded: []byte("a"),
+		},
+		{
+			name:            "smaller decoded than encoded, 2",
+			input:           []byte("abcdefghijklmnopqrstuv"),
+			shouldEncode:    false,
+			expectedEncoded: []byte("abcdefghijklmnopqrstuv"),
+		},
+		{
+			name:            "encoded, 1",
+			input:           []byte("aaa"),
+			shouldEncode:    true,
+			expectedEncoded: []byte{0x6, 0x61},
+		},
+		{
+			name:            "encoded, 2",
+			input:           []byte("aaaaaaaa"),
+			shouldEncode:    true,
+			expectedEncoded: []byte{0x10, 0x61},
+		},
+		{
+			name:            "encoded, 3",
+			input:           []byte("AAABBBCCCCDDDDEFFFFFFFFGGH"),
+			shouldEncode:    true,
+			expectedEncoded: []byte{0x6, 0x41, 0x6, 0x42, 0x8, 0x43, 0x8, 0x44, 0x2, 0x45, 0x10, 0x46, 0x4, 0x47},
+		},
+	}
 
-	orig := []byte("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABCCCCDDEFGHHH")
-	encodedData, encoded := Encode(orig)
-	assert.True(t, encoded)
-	log.Println(Decode(encodedData))
-	// assert.Equal(t, "", string(encodedData))
+	for _, tc := range testCases {
+		encodedData, encoded := Encode(tc.input)
+		assert.Equal(t, tc.shouldEncode, encoded, tc.name)
+		assert.Equal(t, tc.expectedEncoded, encodedData, tc.name)
+	}
+}
 
+func Test_Decode(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name            string
+		encoded         []byte
+		expectedErr     error
+		expectedDecoded []byte
+	}{
+		{
+			name:            "empty input",
+			encoded:         []byte{},
+			expectedErr:     nil,
+			expectedDecoded: []byte{},
+		},
+	}
+
+	for _, tc := range testCases {
+		decoded, err := Decode(tc.encoded)
+		if tc.expectedErr != nil {
+			assert.Error(t, err, tc.name)
+		}
+		assert.Equal(t, tc.expectedDecoded, decoded, tc.name)
+	}
 }

--- a/bitfield/rle_test.go
+++ b/bitfield/rle_test.go
@@ -71,7 +71,7 @@ func Test_Encode(t *testing.T) {
 			name:            "encoded, 3",
 			input:           []byte("AAABBBCCCCDDDDEFFFFFFFFGGH"),
 			shouldEncode:    true,
-			expectedEncoded: []byte{0x6, 0x41, 0x6, 0x42, 0x8, 0x43, 0x8, 0x44, 0x2, 0x45, 0x10, 0x46, 0x4, 0x47},
+			expectedEncoded: []byte{0x6, 0x41, 0x6, 0x42, 0x8, 0x43, 0x8, 0x44, 0x2, 0x45, 0x10, 0x46, 0x4, 0x47, 0x2, 0x48},
 		},
 	}
 
@@ -137,5 +137,50 @@ func Test_Decode(t *testing.T) {
 			assert.NoError(t, err, tc.name)
 			assert.Equal(t, string(tc.expectedDecoded), string(decoded), tc.name)
 		}
+func Test_EncodeAndDecode(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		input       []byte
+		expectedErr error
+	}{
+		{
+			name:        "empty input",
+			input:       []byte{},
+			expectedErr: nil,
+		},
+		{
+			name:        "valid, 1",
+			input:       []byte("aaaaaa"),
+			expectedErr: nil,
+		},
+		{
+			name:        "valid, 2",
+			input:       []byte("aaabcccccccccddd"),
+			expectedErr: nil,
+		},
+		{
+			name:        "valid, 3",
+			input:       []byte("aaabcccccccccdddeeeeeeeeeefghi"),
+			expectedErr: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			encoded, _ := Encode(tc.input)
+
+			decoded, err := Decode(encoded)
+			if tc.expectedErr != nil {
+				assert.Error(t, err, tc.name)
+				assert.Equal(t, err, tc.expectedErr)
+			} else {
+				assert.NoError(t, err, tc.name)
+				assert.Equal(t, string(tc.input), string(decoded), tc.name)
+			}
+		})
 	}
 }

--- a/bitfield/rle_test.go
+++ b/bitfield/rle_test.go
@@ -29,6 +29,7 @@ func Test_Varint(t *testing.T) {
 		assert.Equal(t, count, tc)
 	}
 }
+
 func Test_Encode(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
@@ -76,14 +77,19 @@ func Test_Encode(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		encodedData, encoded := Encode(tc.input)
-		assert.Equal(t, tc.shouldEncode, encoded, tc.name)
-		assert.Equal(t, tc.expectedEncoded, encodedData, tc.name)
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			encodedData, encoded := Encode(tc.input)
+			assert.Equal(t, tc.shouldEncode, encoded, tc.name)
+			assert.Equal(t, tc.expectedEncoded, encodedData, tc.name)
+		})
 	}
 }
 
 func Test_Decode(t *testing.T) {
 	t.Parallel()
+
 	testCases := []struct {
 		name            string
 		encoded         []byte
@@ -129,14 +135,21 @@ func Test_Decode(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		decoded, err := Decode(tc.encoded)
-		if tc.expectedErr != nil {
-			assert.Error(t, err, tc.name)
-			assert.Equal(t, err, tc.expectedErr)
-		} else {
-			assert.NoError(t, err, tc.name)
-			assert.Equal(t, string(tc.expectedDecoded), string(decoded), tc.name)
-		}
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			decoded, err := Decode(tc.encoded)
+			if tc.expectedErr != nil {
+				assert.Error(t, err, tc.name)
+				assert.Equal(t, err, tc.expectedErr)
+			} else {
+				assert.NoError(t, err, tc.name)
+				assert.Equal(t, string(tc.expectedDecoded), string(decoded), tc.name)
+			}
+		})
+	}
+}
+
 func Test_EncodeAndDecode(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
adds Encode and Decode functions for bitfields. uses run-length encoding to allow for potentially shortening a lengthy bitfield